### PR TITLE
fix: add a line break to the end of the output of `lip --version`

### DIFF
--- a/internal/cmd/cmdlip/cmdlip.go
+++ b/internal/cmd/cmdlip/cmdlip.go
@@ -92,7 +92,7 @@ func Run(ctx *context.Context, args []string) error {
 
 	// Version flag has the second highest priority.
 	if flagDict.versionFlag {
-		fmt.Printf("lip %v from %v", ctx.LipVersion().String(), os.Args[0])
+		fmt.Printf("lip %v from %v\n", ctx.LipVersion().String(), os.Args[0])
 		return nil
 	}
 


### PR DESCRIPTION
## What does this PR do?

add a line break to the end of the output of `lip --version`

## Which issues does this PR resolve?

None

## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows [Google Go Style Guide](https://google.github.io/styleguide/go/)
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
