### PR TITLE
fix: fix wrong placements type caused by lip manifest v2 when files p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.2] - 2025-03-07
+
+### Fixed
+
+- Fixed wrong placements type caused by lip manifest v2 when files property is not in platforms property
+
 ## [0.26.1] - 2025-03-07
 
 ### Fixed
@@ -511,6 +517,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#140]: https://github.com/futrime/lip/issues/140
 [#157]: https://github.com/futrime/lip/issues/157
 
+[0.26.2]: https://github.com/futrime/lip/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/futrime/lip/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/futrime/lip/compare/v0.25.1...v0.26.0
 [0.25.1]: https://github.com/futrime/lip/compare/v0.25.0...v0.25.1

--- a/Lip.Migration/MigratorFromV2.cs
+++ b/Lip.Migration/MigratorFromV2.cs
@@ -39,11 +39,9 @@ public static class MigratorFromV2
                 Tags = manifestV2.Info.Tags,
                 AvatarUrl = manifestV2.Info.AvatarUrl
             },
-            Variants = [
-                new Manifest.Variant
-                {
-                    Platform = RuntimeInformation.RuntimeIdentifier,
-                },
+            Variants =
+            [
+                new Manifest.Variant { Platform = RuntimeInformation.RuntimeIdentifier, },
                 new Manifest.Variant
                 {
                     Dependencies = manifestV2.Dependencies,
@@ -60,22 +58,25 @@ public static class MigratorFromV2
                                     "zip" => Manifest.Asset.TypeEnum.Zip,
                                     _ => Manifest.Asset.TypeEnum.Uncompressed
                                 },
-                                Urls = [
+                                Urls =
+                                [
                                     manifestV2.AssetUrl
                                 ],
                                 Placements = manifestV2.Files?.Place?.Select(ConvertPlaceToPlacement)
-                                                                     .ToList()
+                                    .ToList()
                             }
                         ]
-                        :
-                        [
-                            new Manifest.Asset
-                            {
-                                Type = Manifest.Asset.TypeEnum.Self,
-                                Placements = manifestV2.Files?.Place?.Select(ConvertPlaceToPlacement)
-                                                                     .ToList()
-                            }
-                        ],
+                        : manifestV2.Platforms is null
+                            ?
+                            [
+                                new Manifest.Asset
+                                {
+                                    Type = Manifest.Asset.TypeEnum.Self,
+                                    Placements = manifestV2.Files?.Place?.Select(ConvertPlaceToPlacement)
+                                        .ToList()
+                                }
+                            ]
+                            : [],
                     PreserveFiles = manifestV2.Files?.Preserve,
                     RemoveFiles = manifestV2.Files?.Remove,
                     Scripts = manifestV2.Commands is not null
@@ -88,7 +89,8 @@ public static class MigratorFromV2
                         Platform = ConvertGOARCHAndGOOSToPlatform(p.GOARCH, p.GOOS),
                         Dependencies = p.Dependencies,
                         Assets = p.AssetUrl is not null
-                            ? [
+                            ?
+                            [
                                 new Manifest.Asset
                                 {
                                     Type = p.AssetUrl.Split('.').Last() switch
@@ -99,11 +101,15 @@ public static class MigratorFromV2
                                         "zip" => Manifest.Asset.TypeEnum.Zip,
                                         _ => Manifest.Asset.TypeEnum.Uncompressed
                                     },
-                                    Urls = [
+                                    Urls =
+                                    [
                                         p.AssetUrl
                                     ],
-                                    Placements = p.Files?.Place?.Select(ConvertPlaceToPlacement)
-                                                        .ToList()
+                                    Placements = manifestV2.Files?.Place is not null
+                                        ? manifestV2.Files?.Place?.Select(ConvertPlaceToPlacement)
+                                            .ToList()
+                                        : p.Files?.Place?.Select(ConvertPlaceToPlacement)
+                                            .ToList(),
                                 }
                             ]
                             : null,


### PR DESCRIPTION
…roperty is not in platforms property

## What does this PR do?

Fix wrong placements type caused by lip manifest v2 when files property is not in platforms property

## Which issues does this PR resolve?

No

## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows our code style
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
