### PR TITLE
refactor: modify `files.place` priority in manifest v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- If `files.place` exists both inside and outside `platforms` in manifest v2, the `files.place` in the `platforms` takes
+  precedence.
+
 ## [0.26.2] - 2025-03-07
 
 ### Fixed
@@ -517,6 +524,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#140]: https://github.com/futrime/lip/issues/140
 [#157]: https://github.com/futrime/lip/issues/157
 
+[Unreleased]: https://github.com/futrime/lip/compare/v0.26.2...HEAD
 [0.26.2]: https://github.com/futrime/lip/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/futrime/lip/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/futrime/lip/compare/v0.25.1...v0.26.0

--- a/Lip.Migration/MigratorFromV2.cs
+++ b/Lip.Migration/MigratorFromV2.cs
@@ -105,7 +105,7 @@ public static class MigratorFromV2
                                     [
                                         p.AssetUrl
                                     ],
-                                    Placements = manifestV2.Files?.Place is not null
+                                    Placements = manifestV2.Files?.Place is not null && p.Files?.Place is null
                                         ? manifestV2.Files?.Place?.Select(ConvertPlaceToPlacement)
                                             .ToList()
                                         : p.Files?.Place?.Select(ConvertPlaceToPlacement)


### PR DESCRIPTION
## What does this PR do?

If `files.place` exists both inside and outside `platforms` in manifest v2, the `files.place` in the `platforms` takes precedence.

## Which issues does this PR resolve?

No

## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows our code style
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
